### PR TITLE
Update to supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 
-# Use container-based infrastructure
-sudo: false
-
 node_js:
-  - "node"
-  - "6"
+  - "node"  # latest stable release
+  - "lts/*" # latest LTS release
 
 script:
   - yarn run ci


### PR DESCRIPTION
Changes proposed in this pull request:

 * Update to supported node versions to latest stable (now v12) and latest LTS (now v10)
 * https://nodejs.org/en/about/releases/
 * https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions
 * Also sudo is no longer required: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

